### PR TITLE
line obj 관련 버그 픽스

### DIFF
--- a/components/WhiteBoard/LineRenderer.tsx
+++ b/components/WhiteBoard/LineRenderer.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { Line } from '@react-three/drei';
-import { Dispatch, SetStateAction, useEffect } from 'react';
+import { ThreeEvent } from '@react-three/fiber';
+import { Dispatch, SetStateAction, useEffect, useMemo } from 'react';
 
 interface LineRendererProps {
   obj: LineObj;
@@ -15,16 +15,56 @@ export default function LineRenderer({ obj, setDimensions }: LineRendererProps) 
       h: Math.abs(obj.y - obj.y2),
     });
   }, [obj, setDimensions]);
+
   return (
-    <Line
-      points={[
-        [obj.x, obj.y, obj.depth],
-        [obj.x2, obj.y2, obj.depth],
-      ]}
+    <FlatLine
+      x={obj.x}
+      y={obj.y}
+      x2={obj.x2}
+      y2={obj.y2}
+      strokeWidth={obj.strokeWidth}
       color={obj.color}
-      lineWidth={obj.strokeWidth}
-      worldUnits={true}
-      dashed={false}
+      depth={obj.depth}
     />
   );
+}
+
+interface FlatLineProps {
+  x: number;
+  y: number;
+  x2: number;
+  y2: number;
+  strokeWidth: number;
+  color: string;
+  depth: number;
+  onPointerDown?: (event: ThreeEvent<PointerEvent>) => void;
+}
+
+export function FlatLine({
+  x,
+  y,
+  x2,
+  y2,
+  strokeWidth,
+  color,
+  depth,
+  onPointerDown,
+}: FlatLineProps) {
+  const { w, d } = useMemo(() => calculate(x, y, x2, y2), [x - x2, y - y2]);
+  return (
+    <mesh
+      position={[(x + x2) / 2, (y + y2) / 2, depth]}
+      rotation={[0, 0, d]}
+      onPointerDown={onPointerDown}
+    >
+      <planeGeometry attach={'geometry'} args={[w, strokeWidth]} />
+      <meshStandardMaterial color={color} depthWrite={true} depthTest={true} />
+    </mesh>
+  );
+}
+
+function calculate(x: number, y: number, x2: number, y2: number) {
+  const w = Math.sqrt(Math.pow(x - x2, 2) + Math.pow(y - y2, 2));
+  const d = Math.atan2(y2 - y, x2 - x);
+  return { w, d };
 }

--- a/components/WhiteBoard/ObjectPropertyEditor/index.tsx
+++ b/components/WhiteBoard/ObjectPropertyEditor/index.tsx
@@ -185,7 +185,14 @@ function LinePanel({ obj, onChange }: LinePanelProps) {
   return (
     <div className={styles.panel}>
       <Property propKey="x2" propVal={obj.x2.toString()} onChange={onChange} type="NUMBER" />
-      <Property propKey="y2" propVal={obj.x2.toString()} onChange={onChange} type="NUMBER" />
+      <Property propKey="y2" propVal={obj.y2.toString()} onChange={onChange} type="NUMBER" />
+      <Property
+        propKey={'strokeWidth'}
+        label="굵기"
+        propVal={obj.strokeWidth.toString()}
+        onChange={onChange}
+        type="NUMBER"
+      />
       <Property
         propKey={'color'}
         label="색상"

--- a/components/WhiteBoard/SelectionRenderer.tsx
+++ b/components/WhiteBoard/SelectionRenderer.tsx
@@ -9,9 +9,10 @@ import {
   getPos,
   FRAME_CORNER_DEPTH,
 } from '@/utils/whiteboardHelper';
-import { Circle, Line } from '@react-three/drei';
+import { Circle } from '@react-three/drei';
 import { ThreeEvent, useFrame, useThree } from '@react-three/fiber';
 import { useState } from 'react';
+import { FlatLine } from './LineRenderer';
 
 interface SelectionRendererProps {
   dimensions: ObjDimensions;
@@ -70,47 +71,58 @@ function WireFrame({
   dimensions: ObjDimensions;
   onPointerDown: (e: ThreeEvent<PointerEvent>, mode: DragMode) => void;
 }) {
+  const [zoom, setZoom] = useState<number>(0);
+
+  useFrame((s) => {
+    setZoom(s.camera.zoom);
+  });
+  if (zoom === 0) return null;
+
   return (
     <>
       {/* N */}
-      <Line
+      <FlatLine
         onPointerDown={(e) => onPointerDown(e, 'n')}
-        points={[
-          [dimensions.x, dimensions.y + dimensions.h, FRAME_DEPTH],
-          [dimensions.x + dimensions.w, dimensions.y + dimensions.h, FRAME_DEPTH],
-        ]}
+        x={dimensions.x}
+        y={dimensions.y + dimensions.h}
+        x2={dimensions.x + dimensions.w}
+        y2={dimensions.y + dimensions.h}
+        depth={FRAME_DEPTH}
         color={FRAME_COLOR}
-        lineWidth={FRAME_WIDTH}
+        strokeWidth={FRAME_WIDTH / zoom}
       />
       {/* E */}
-      <Line
+      <FlatLine
         onPointerDown={(e) => onPointerDown(e, 'e')}
-        points={[
-          [dimensions.x + dimensions.w, dimensions.y, FRAME_DEPTH],
-          [dimensions.x + dimensions.w, dimensions.y + dimensions.h, FRAME_DEPTH],
-        ]}
+        x={dimensions.x + dimensions.w}
+        y={dimensions.y}
+        x2={dimensions.x + dimensions.w}
+        y2={dimensions.y + dimensions.h}
+        depth={FRAME_DEPTH}
         color={FRAME_COLOR}
-        lineWidth={FRAME_WIDTH}
+        strokeWidth={FRAME_WIDTH / zoom}
       />
       {/* W */}
-      <Line
+      <FlatLine
         onPointerDown={(e) => onPointerDown(e, 'w')}
-        points={[
-          [dimensions.x, dimensions.y, FRAME_DEPTH],
-          [dimensions.x, dimensions.y + dimensions.h, FRAME_DEPTH],
-        ]}
+        x={dimensions.x}
+        y={dimensions.y}
+        x2={dimensions.x}
+        y2={dimensions.y + dimensions.h}
+        depth={FRAME_DEPTH}
         color={FRAME_COLOR}
-        lineWidth={FRAME_WIDTH}
+        strokeWidth={FRAME_WIDTH / zoom}
       />
       {/* S */}
-      <Line
+      <FlatLine
         onPointerDown={(e) => onPointerDown(e, 's')}
-        points={[
-          [dimensions.x, dimensions.y, FRAME_DEPTH],
-          [dimensions.x + dimensions.w, dimensions.y, FRAME_DEPTH],
-        ]}
+        x={dimensions.x}
+        y={dimensions.y}
+        x2={dimensions.x + dimensions.w}
+        y2={dimensions.y}
+        depth={FRAME_DEPTH}
         color={FRAME_COLOR}
-        lineWidth={FRAME_WIDTH}
+        strokeWidth={FRAME_WIDTH / zoom}
       />
     </>
   );

--- a/components/WhiteBoard/index.tsx
+++ b/components/WhiteBoard/index.tsx
@@ -4,6 +4,7 @@ import { Canvas } from '@react-three/fiber';
 import NodeRenderer from './NodeRenderer';
 import MouseHandler from './MouseHandler';
 import { useWhiteBoard } from '@/states/whiteboard';
+import { Line, OrbitControls, Segment, Segments } from '@react-three/drei';
 
 interface WhiteBoardProps {
   style?: CSSProperties;
@@ -19,6 +20,18 @@ export default function WhiteBoard({ style }: WhiteBoardProps) {
       camera={{ position: [0, 0, 100], zoom: 1 }}
       orthographic
     >
+      <Line
+        points={[
+          [0, 0, 1],
+          [200, 0, 1],
+        ]}
+        lineWidth={30}
+        color={'red'}
+        worldUnits={true}
+        precision={'highp'}
+        depthWrite={false}
+      />
+
       <ambientLight />
       <NodeRenderer node={objTree} />
       <MouseHandler />


### PR DESCRIPTION
## 개요

- #44

## 작업사항

- line obj가 objPropertyEditor에 제대로 표시되지 않는 버그 픽스
- line obj renderer 수정
  - drei/Line 대신 planeGeometry 사용: drei의 line은 3d 임. 또한 orthographic camera에서도 perspective distortion 처럼 보이는 현상이 발생함
