### PR TITLE
화이트보드 렌더러 재구현

### DIFF
--- a/app/document/[documentId]/components/GenerateDialogue.tsx
+++ b/app/document/[documentId]/components/GenerateDialogue.tsx
@@ -25,7 +25,7 @@ type PreviewMode = 'tree' | 'force';
 export default function GenerateDialouge({ onCancel }: GenerateDialogueProps) {
   const [text, setText] = useState<string>('');
   const [state, setState] = useState<ScreenState>('input');
-  const [rawGraphData, setRawGraphData] = useState<MindmapResponse | null>(null);
+  const [rawGraphData, setRawGraphData] = useState<ThreeGraphData | null>(null);
   const [previewMode, setPreviewMode] = useState<PreviewMode>('tree');
   const [previewBundle, setPreviewBundle] = useState<ObjBundle | null>(null);
   const [previewTree, setPreviewTree] = useState<ObjNode | null>(null);

--- a/app/document/[documentId]/page.tsx
+++ b/app/document/[documentId]/page.tsx
@@ -8,7 +8,7 @@ import DocumentTitle from './components/DocumentTitle';
 import ToolSelector from '@/components/WhiteBoard/ToolSelector';
 import LoadingScreen from '../../../components/LoadingScreen';
 import PdfViewer from '@/components/PdfViewer';
-const WhiteBoard = dynamic(() => import('@/components/WhiteBoard'), { ssr: false });
+const GraphCanvas = dynamic(() => import('@/components/GraphCanvas'), { ssr: false });
 
 interface DocumentPageProps {
   params: { documentId: string };
@@ -69,7 +69,7 @@ export default function DoucumentsPage({ params }: DocumentPageProps) {
           </div>
           <div className={styles.whiteBoardContainer}>
             <Suspense fallback={<LoadingScreen message={'Loading renderer'} />}>
-              <WhiteBoard />
+              <GraphCanvas />
             </Suspense>
           </div>
         </div>

--- a/components/GraphCanvas/GraphRenderer.tsx
+++ b/components/GraphCanvas/GraphRenderer.tsx
@@ -1,0 +1,377 @@
+'use client';
+import { MutableRefObject, RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { invalidate, useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+import { DEFAULT_FONT, boundNumber, calculateLineGeometry, getPos } from '@/utils/whiteboardHelper';
+import * as d3 from 'd3';
+// @ts-ignore
+import { Text, preloadFont } from 'troika-three-text';
+import { useGraph } from '@/states/graph';
+
+const GAP = 10;
+const RADIUS = 5;
+const MAXSCALE = 2;
+const MINSCALE = 1;
+const MINDELTA = 0.01;
+const WHEEL_DELTA_FACTOR = 100;
+const WHEEL_MAX_DELTA = 20;
+const PAN_MAX_DELTA = 100;
+const MAX_ZOOM = 10000;
+const MIN_ZOOM = 0.1;
+
+interface GraphRendererProps {
+  data: GraphData;
+}
+
+export default function GraphRenderer({ data }: GraphRendererProps) {
+  const groupRef = useRef<THREE.Group>(null);
+  const [fontLoaded, setFontLoaded] = useState<boolean>(false);
+  const geometry = useMemo(() => new THREE.CircleGeometry(1, 32), []);
+  const lineGeometry = useMemo(() => new THREE.PlaneGeometry(1, 1), []);
+  const nodeMaterial = useMemo(() => new THREE.MeshBasicMaterial({ color: 'grey' }), []);
+  const lineMaterial = useMemo(
+    () => new THREE.MeshBasicMaterial({ color: 'grey', opacity: 0.3, transparent: true }),
+    [],
+  );
+  const selectedNodeMaterial = useMemo(() => new THREE.MeshBasicMaterial({ color: 'blue' }), []);
+
+  const nodeDataFactory = useMemo(
+    () =>
+      ([id, keyword]: [number, string]) => {
+        // group
+        const group = new THREE.Group();
+        // circle
+        const circle = new THREE.Mesh(geometry, nodeMaterial);
+        circle.position.setZ(10);
+        circle.scale.set(RADIUS, RADIUS, 1);
+        group.add(circle);
+        // label
+        const text = new Text();
+        text.font = DEFAULT_FONT;
+        text.fontSize = 15;
+        text.text = keyword;
+        text.color = 'black';
+        text.position.setZ(15);
+        text.position.setY(RADIUS);
+        text.anchorX = 'center';
+        text.anchorY = 'bottom';
+        text.transparent = false;
+        text.outlineWidth = 2;
+        text.outlineColor = 'white';
+        group.add(text);
+
+        // mount mesh
+        groupRef.current!.add(group);
+
+        return {
+          id: id,
+          label: keyword,
+          labelMesh: text,
+          circleMesh: circle,
+          scale: 1,
+          group: group,
+          selected: false,
+        } as NodeData;
+      },
+    [geometry, nodeMaterial],
+  );
+
+  const linkDataFactory = useMemo(
+    () =>
+      ([key, children]: [string, number[]]) => {
+        const id = parseInt(key);
+        const links: LinkData[] = [];
+        for (const child of children) {
+          const line = new THREE.Mesh(lineGeometry, lineMaterial);
+          line.scale.setX(0);
+          line.rotation.set(0, 0, 0);
+          groupRef.current!.add(line);
+          links.push({ source: id, target: child, mesh: line } as LinkData);
+        }
+        return links;
+      },
+    [lineGeometry, lineMaterial],
+  );
+
+  const { simulationRef, linksRef } = useSimulation(
+    data,
+    groupRef,
+    fontLoaded,
+    nodeDataFactory,
+    linkDataFactory,
+  );
+
+  const { selectedNodeRef } = usePointer(simulationRef);
+
+  // simulation begins after font preload
+  preloadFont({ font: DEFAULT_FONT }, () => setFontLoaded(true));
+
+  // update scene
+  useFrame(({ camera }) => {
+    if (groupRef.current === null) return;
+    const nodes = simulationRef.current.nodes();
+    const links = linksRef.current;
+    const inverseZoom = 1 / camera.zoom;
+
+    // update node meshes
+    for (const node of nodes) {
+      node.circleMesh.material = nodeMaterial;
+      node.group.position.setX(node.x ?? 0);
+      node.group.position.setY(node.y ?? 0);
+      node.labelMesh.position.setY(RADIUS * node.scale);
+      node.labelMesh.scale.set(node.scale, node.scale, 1);
+      node.circleMesh.scale.set(node.scale * RADIUS, node.scale * RADIUS, 1);
+    }
+
+    // highlight current selected node
+    if (selectedNodeRef.current !== undefined) {
+      selectedNodeRef.current.node.circleMesh.material = selectedNodeMaterial;
+    }
+
+    // update link meshes
+    for (const link of links) {
+      const source = link.source as NodeData;
+      const target = link.target as NodeData;
+      const x = source.x ?? 0;
+      const y = source.y ?? 0;
+      const x2 = target.x ?? 0;
+      const y2 = target.y ?? 0;
+      const { w, d } = calculateLineGeometry(x, y, x2, y2);
+      link.mesh.position.set((x + x2) / 2, (y + y2) / 2, 10);
+      link.mesh.scale.setY(inverseZoom);
+      link.mesh.scale.setX(w);
+      link.mesh.rotation.set(0, 0, d);
+    }
+  });
+
+  return <group ref={groupRef}></group>;
+}
+
+function usePointer(simulationRef: MutableRefObject<d3.Simulation<NodeData, undefined>>) {
+  const {
+    gl: { domElement },
+    mouse,
+    camera,
+  } = useThree();
+  const rayCaster = useMemo(() => new THREE.Raycaster(), []);
+  const selectedNodeRef = useRef<RayCastResult>(); // current selection
+  const pointerDownRef = useRef<PointerHistory>();
+
+  const setSelected = useGraph((state) => state.setSelected);
+
+  // pointer event handlers
+  useEffect(() => {
+    const pointerMove = () => invalidate();
+    const wheel = (e: WheelEvent) => {
+      e.preventDefault();
+      // pinch zoom
+      if (e.ctrlKey) {
+        const boundDelta = boundNumber(e.deltaY, -WHEEL_MAX_DELTA, WHEEL_MAX_DELTA);
+        const newZoom = camera.zoom - (boundDelta * camera.zoom) / WHEEL_DELTA_FACTOR;
+        if (newZoom < MIN_ZOOM) camera.zoom = MIN_ZOOM;
+        else if (newZoom > MAX_ZOOM) camera.zoom = MAX_ZOOM;
+        else camera.zoom = newZoom;
+        camera.updateProjectionMatrix();
+      } else {
+        // scroll pan
+        camera.position.setX(
+          camera.position.x + boundNumber(e.deltaX, -PAN_MAX_DELTA, PAN_MAX_DELTA) / camera.zoom,
+        );
+        camera.position.setY(
+          camera.position.y - boundNumber(e.deltaY, -PAN_MAX_DELTA, PAN_MAX_DELTA) / camera.zoom,
+        );
+      }
+      invalidate();
+    };
+
+    const pointerUp = (e: MouseEvent) => {
+      if (pointerDownRef.current === undefined) return;
+      const upPos = new THREE.Vector2(e.clientX, e.clientY);
+      const down = pointerDownRef.current;
+      pointerDownRef.current = undefined;
+      if (selectedNodeRef.current === undefined) return;
+      selectedNodeRef.current.node.fx = undefined;
+      selectedNodeRef.current.node.fy = undefined;
+      const isBlankClick =
+        upPos.x === down.pos.x && upPos.y === down.pos.y && down.intersection === undefined;
+      if (isBlankClick) {
+        setSelected(undefined);
+        selectedNodeRef.current = undefined;
+      }
+      simulationRef.current.alphaTarget(0);
+      invalidate();
+    };
+
+    const pointerDown = (e: MouseEvent) => {
+      rayCaster.setFromCamera(mouse, camera);
+      const intersection = intersectingNode(simulationRef.current.nodes(), rayCaster);
+      pointerDownRef.current = {
+        realPos: getPos(mouse, camera),
+        pos: new THREE.Vector2(e.clientX, e.clientY),
+        intersection: intersection,
+      };
+      if (intersection === undefined) return;
+      // pointer down on node
+      setSelected(intersection.node);
+      selectedNodeRef.current = intersection;
+      selectedNodeRef.current.node.group.position.setZ(100);
+      simulationRef.current.alphaTarget(0.1).restart();
+    };
+    domElement.addEventListener('pointermove', pointerMove);
+    domElement.addEventListener('pointerup', pointerUp);
+    domElement.addEventListener('pointerdown', pointerDown);
+    domElement.addEventListener('wheel', wheel);
+    return () => {
+      domElement.removeEventListener('pointermove', pointerMove);
+      domElement.removeEventListener('pointerup', pointerUp);
+      domElement.removeEventListener('pointerdown', pointerDown);
+      domElement.removeEventListener('wheel', wheel);
+    };
+  }, [camera, domElement, mouse, rayCaster, setSelected, simulationRef]);
+
+  // mouse handler
+  useFrame(({ camera, mouse }) => {
+    rayCaster.setFromCamera(mouse, camera);
+    const nodes = simulationRef.current.nodes();
+    const inverseZoom = 1 / camera.zoom;
+
+    // pointer is clicked
+    if (pointerDownRef.current !== undefined) {
+      const intersection = pointerDownRef.current.intersection;
+      const mouseRealPos = getPos(mouse, camera);
+      if (intersection !== undefined) {
+        // node is selected -> move node
+        intersection.node.fx = mouseRealPos.x + intersection.offset.x;
+        intersection.node.fy = mouseRealPos.y + intersection.offset.y;
+      } else {
+        // node is not selected -> pan camera
+        camera.position.setX(
+          pointerDownRef.current.realPos.x - (mouseRealPos.x - camera.position.x),
+        );
+        camera.position.setY(
+          pointerDownRef.current.realPos.y - (mouseRealPos.y - camera.position.y),
+        );
+      }
+    }
+
+    // scale up intersecting nodes
+    const node_scale_max = Math.max(MAXSCALE * inverseZoom, MAXSCALE);
+    for (const node of nodes) {
+      // check intersection
+      if (
+        rayCaster.intersectObject(node.group).length > 0 ||
+        node === selectedNodeRef.current?.node
+      ) {
+        // intersect
+        if (node.scale < node_scale_max) {
+          // scale needs update
+          node.scale += Math.max((node_scale_max - node.scale) / 5, MINDELTA);
+          invalidate();
+        } else node.scale = node_scale_max;
+      } else {
+        // does not intersect
+        node.group.position.setZ(0);
+        if (node.scale > MINSCALE) {
+          // scale needs update
+          node.scale -= Math.max((node.scale - MINSCALE) / 5, MINDELTA);
+          invalidate();
+        } else node.scale = MINSCALE;
+      }
+    }
+  });
+
+  return { selectedNodeRef };
+}
+
+function useSimulation(
+  data: GraphData,
+  groupRef: RefObject<THREE.Group>,
+  fontLoaded: boolean,
+  nodeDataFactory: ([id, keyword]: [number, string]) => NodeData,
+  linkDataFactory: ([key, children]: [string, number[]]) => LinkData[],
+) {
+  const simulationRef = useRef<d3.Simulation<NodeData, undefined>>(d3.forceSimulation<NodeData>());
+  const linksRef = useRef<LinkData[]>([]);
+
+  useEffect(() => {
+    // if simulation exists, stop
+    if (simulationRef.current != null) simulationRef.current.stop();
+
+    // regenerated on graph data update
+    if (groupRef.current == null) return;
+
+    // remove items from mesh group
+    for (const child of groupRef.current.children) {
+      child.removeFromParent();
+      if (child.hasOwnProperty('dispose')) (child as any).dispose(); // prevent memory leak
+    }
+
+    groupRef.current.clear();
+
+    if (!fontLoaded) return;
+
+    // generate nodes
+    const nodes: NodeData[] = [];
+    for (const entry of data.keywords.entries()) {
+      nodes.push(nodeDataFactory(entry));
+    }
+
+    // generate links
+    const graph = new Map<string, number[]>(Object.entries(data.graph));
+    linksRef.current = [];
+    for (const entry of graph.entries()) {
+      const links = linkDataFactory(entry);
+      for (const link of links) linksRef.current.push(link);
+    }
+
+    simulationRef.current
+      .nodes(nodes)
+      .force('charge', d3.forceManyBody<NodeData>().strength(-1000).distanceMax(500))
+      .force(
+        'link',
+        d3
+          .forceLink<NodeData, LinkData>(linksRef.current)
+          .id((d) => d.id)
+          .strength(1),
+      )
+      .force('center', d3.forceCenter(0, 0).strength(1))
+      .force('collision', d3.forceCollide(GAP))
+      .tick(50);
+
+    simulationRef.current.on('tick', () => {
+      // rerender
+      invalidate();
+    });
+
+    simulationRef.current.alpha(1).restart();
+  }, [data.graph, data.keywords, fontLoaded, groupRef, linkDataFactory, nodeDataFactory]);
+  return { simulationRef, linksRef };
+}
+
+function intersectingNode(nodes: NodeData[], rayCaster: THREE.Raycaster) {
+  for (const node of nodes) {
+    // check intersection
+    const points = rayCaster.intersectObject(node.group);
+    if (points.length > 0) {
+      return {
+        node: node,
+        offset: new THREE.Vector2(
+          (node.x ?? 0) - points[0].point.x,
+          (node.y ?? 0) - points[0].point.y,
+        ),
+      };
+    }
+  }
+  return undefined;
+}
+
+interface RayCastResult {
+  node: NodeData;
+  offset: THREE.Vector2;
+}
+
+interface PointerHistory {
+  pos: THREE.Vector2;
+  realPos: THREE.Vector2;
+  intersection?: RayCastResult;
+}

--- a/components/GraphCanvas/index.tsx
+++ b/components/GraphCanvas/index.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { CSSProperties, useEffect } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { useWhiteBoard } from '@/states/whiteboard';
+import { useGraph } from '@/states/graph';
+import dynamic from 'next/dynamic';
+const GraphRenderer = dynamic(() => import('./GraphRenderer'), { ssr: false });
+
+interface GraphCanvasProps {
+  style?: CSSProperties;
+}
+
+export default function GraphCanvas({ style }: GraphCanvasProps) {
+  const graphData = useWhiteBoard((state) => state.graphData);
+  const selected = useGraph((state) => state.selected);
+  useEffect(() => {
+    console.log(selected);
+  }, [selected]);
+
+  if (graphData === null) return <></>;
+
+  return (
+    <Canvas
+      flat
+      frameloop="demand"
+      style={style}
+      camera={{ position: [0, 0, 1000], zoom: 1, far: 1000000, near: 0 }}
+      orthographic
+    >
+      <ambientLight />
+      <GraphRenderer data={graphData} />
+    </Canvas>
+  );
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -32,7 +32,7 @@ interface ObjDimensions {
 
 interface LiveGraphObj extends Obj {
   type: 'LIVEGRAPH';
-  data: MindmapResponse;
+  data: GraphData;
 }
 
 interface GraphNodeObj extends Obj {
@@ -54,12 +54,27 @@ interface CircleOptions {
   color?: string;
 }
 
-interface GraphData {
-  nodes: NodeData[];
-  links: LinkData[];
+interface ThreeGraphData {
+  nodes: NodeDataLegacy[];
+  links: LinkDataLegacy[];
 }
 
 interface NodeData {
+  id: number;
+  label: string;
+  labelMesh: THREE.Mesh;
+  circleMesh: THREE.Mesh;
+  group: THREE.Group;
+  scale: number;
+  x?: number;
+  y?: number;
+  fx?: number;
+  fy?: number;
+  vx?: number;
+  vy?: number;
+}
+
+interface NodeDataLegacy {
   id: string;
   name: string;
   val: number;
@@ -69,6 +84,12 @@ interface NodeData {
 }
 
 interface LinkData {
+  source: number | NodeData;
+  target: number | NodeData;
+  mesh: THREE.Mesh;
+}
+
+interface LinkDataLegacy {
   source: string;
   target: string;
   color: string;
@@ -133,6 +154,7 @@ type WBDocumentData = Map<string, Obj>;
 
 interface WBDocument extends WBDocumentMetadata {
   documentData: WBDocumentData;
+  graphData: GraphData;
 }
 
 type WBDocumentListReponse = WBDocumentMetaData[];
@@ -161,7 +183,7 @@ interface TextRequest {
   text: string;
 }
 
-interface MindmapResponse {
+interface GraphData {
   root: number;
   keywords: string[];
   graph: Map<string, number[]>;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/react-pdf": "^7.0.0",
     "@types/three": "^0.154.0",
     "d3": "^7.8.5",
-    "d3-force-3d": "^3.0.5",
     "eslint": "8.44.0",
     "eslint-config-next": "13.4.9",
     "material-symbols": "^0.10.1",
@@ -27,7 +26,7 @@
     "react-dom": "18.2.0",
     "react-pdf": "^7.5.0",
     "three": "^0.154.0",
-    "three-forcegraph": "^1.41.10",
+    "troika-three-text": "^0.49.0",
     "typescript": "5.1.6",
     "zustand": "^4.4.0"
   },

--- a/states/graph.ts
+++ b/states/graph.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface GraphState {
+  selected?: NodeData;
+  setSelected: (selected: NodeData | undefined) => void;
+}
+
+export const useGraph = create<GraphState>((set) => ({
+  selected: undefined,
+  setSelected: (selected) => set({ selected: selected }),
+}));

--- a/states/whiteboard.ts
+++ b/states/whiteboard.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 
 interface WhiteBoardState {
   objMap: Map<string, Obj>;
+  graphData: GraphData | null;
   objTree: ObjNode;
   currentTool: Tool;
   currentObj: string | null;
@@ -22,6 +23,7 @@ interface WhiteBoardActions {
   setBundle: (bundle: ObjBundle) => void;
   removeObj: (obj: Obj, global?: boolean) => void;
   resetWhiteBoard: () => void;
+  removeNode: (node: NodeData) => void;
 }
 
 const ROOT_OBJ = {
@@ -32,6 +34,7 @@ const ROOT_OBJ = {
 
 const initialState = {
   objMap: new Map<string, Obj>(),
+  graphData: null,
   objTree: ROOT_OBJ,
   currentTool: 'SELECT',
   currentObj: null,
@@ -67,7 +70,7 @@ export const useWhiteBoard = create<WhiteBoardState & WhiteBoardActions>()((set,
   loadDocument: async (document: WBDocument) => {
     const newObjMap = new Map<string, Obj>(Object.entries(document.documentData));
     const newObjTree = constructRootObjTree(newObjMap);
-    set(() => ({ objMap: newObjMap, objTree: newObjTree }));
+    set(() => ({ objMap: newObjMap, objTree: newObjTree, graphData: document.graphData }));
   },
   setBundle: (bundle: ObjBundle) => set(() => ({ bundle: bundle })),
   resetWhiteBoard: () => set(() => ({ ...initialState })),
@@ -97,5 +100,13 @@ export const useWhiteBoard = create<WhiteBoardState & WhiteBoardActions>()((set,
     if (global) {
       // TODO: remove from objTree
     }
+  },
+  removeNode: (node) => {
+    const data = get().graphData;
+    if (data === null) return;
+    //get index of node
+    const targetIndex = data.keywords.findIndex((value) => value === node.label);
+    if (targetIndex === -1) return;
+    // delete keyword;
   },
 }));

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -30,7 +30,7 @@ export async function refreshToken(): Promise<string | null> {
   );
 }
 
-export async function generateGraph(text: TextRequest): Promise<MindmapResponse> {
+export async function generateGraph(text: TextRequest): Promise<GraphData> {
   return (await httpPost(`${AI_BASE_URL}/mindmap`, text))?.json();
 }
 

--- a/utils/whiteboardHelper.ts
+++ b/utils/whiteboardHelper.ts
@@ -209,7 +209,7 @@ export function createLine(
 const vector3 = new Vector3();
 export function getPos(mouse: Vector2, camera: Camera, validate: boolean = false) {
   const { x, y } = vector3.set(mouse.x, mouse.y, 0).unproject(camera);
-  return { x: validate ? validateValue(x) : x, y: validate ? validateValue(y) : y };
+  return new Vector2(validate ? validateValue(x) : x, validate ? validateValue(y) : y);
 }
 
 /**
@@ -364,7 +364,7 @@ interface LinkData {
   target: number;
 }
 
-export function createTreeFromMindmap(response: MindmapResponse): ObjBundle {
+export function createTreeFromMindmap(response: GraphData): ObjBundle {
   let top = topDepth();
   const fontSize = 30;
   const edgeColor = '#dddddd';
@@ -431,7 +431,7 @@ export function createTreeFromMindmap(response: MindmapResponse): ObjBundle {
   };
 }
 
-export function createForceBundleFromMindmap(response: MindmapResponse): ObjBundle {
+export function createForceBundleFromMindmap(response: GraphData): ObjBundle {
   const fontSize = 20;
   const radius = 50;
   const edgeWidth = 2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,11 +671,6 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accessor-fn@1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/accessor-fn/-/accessor-fn-1.5.0.tgz#9353e10194da404366657f47177cd9bcb4463ee7"
-  integrity sha512-dml7D96DY/K5lt4Ra2jMnpL9Bhw5HEGws4p1OAIxFFj9Utd/RxNfEO3T3f0QIWFNwQU7gNxH9snUfqF/zNkP/w==
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -983,7 +978,7 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
@@ -994,11 +989,6 @@ d3-axis@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
   integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
-
-d3-binarytree@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-binarytree/-/d3-binarytree-1.0.2.tgz#ed43ebc13c70fbabfdd62df17480bc5a425753cc"
-  integrity sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==
 
 d3-brush@3:
   version "3.0.0"
@@ -1071,17 +1061,6 @@ d3-fetch@3:
   dependencies:
     d3-dsv "1 - 3"
 
-"d3-force-3d@2 - 3", d3-force-3d@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/d3-force-3d/-/d3-force-3d-3.0.5.tgz#9c8931b49acc3554f9110e128bc580cd3ab830f2"
-  integrity sha512-tdwhAhoTYZY/a6eo9nR7HP3xSW/C6XvJTbeRpR92nlPzH6OiE+4MliN9feuSFd0tPtEUo+191qOhCTWx3NYifg==
-  dependencies:
-    d3-binarytree "1"
-    d3-dispatch "1 - 3"
-    d3-octree "1"
-    d3-quadtree "1 - 3"
-    d3-timer "1 - 3"
-
 d3-force@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
@@ -1115,11 +1094,6 @@ d3-hierarchy@3:
   dependencies:
     d3-color "1 - 3"
 
-d3-octree@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-octree/-/d3-octree-1.0.2.tgz#b39026b82701e45c7163e34ee056dc492035a017"
-  integrity sha512-Qxg4oirJrNXauiuC94uKMbgxwnhdda9xRLl9ihq45srlJ4Ga3CSgqGcAL8iW7N5CIv4Oz8x3E734ulxyvHPvwA==
-
 "d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
@@ -1140,7 +1114,7 @@ d3-random@3:
   resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
   integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
 
-"d3-scale-chromatic@1 - 3", d3-scale-chromatic@3:
+d3-scale-chromatic@3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
   integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
@@ -1148,7 +1122,7 @@ d3-random@3:
     d3-color "1 - 3"
     d3-interpolate "1 - 3"
 
-"d3-scale@1 - 4", d3-scale@4:
+d3-scale@4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
   integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
@@ -1252,13 +1226,6 @@ damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
-
-data-joint@1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/data-joint/-/data-joint-1.3.1.tgz#d134950322c90f531e81bbbe8454277549031466"
-  integrity sha512-tMK0m4OVGqiA3zkn8JmO6YAqD8UwJqIAx4AAwFl1SKTtKAqcXePuT+n2aayiX9uITtlN3DFtKKTOxJRUc2+HvQ==
-  dependencies:
-    index-array-by "^1.4.0"
 
 debounce@^1.2.1:
   version "1.2.1"
@@ -2056,11 +2023,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-index-array-by@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/index-array-by/-/index-array-by-1.4.1.tgz#425f26cf0c744a47ebadf47366692e52043cf17b"
-  integrity sha512-Zu6THdrxQdyTuT2uA5FjUoBEsFHPzHcPIj18FszN6yXKHxSfGcR4TPLabfuT//E25q1Igyx9xta2WMvD/x9P/g==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2302,13 +2264,6 @@ json5@^1.0.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-kapsule@1:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/kapsule/-/kapsule-1.14.4.tgz#55f19fe7a04dfe111e9efc7d85a895e6440ef828"
-  integrity sha512-Ro1US5B5mtyZMM+NqW/0fqcBf9oEO7fG0gYY9FY+BVGo4KaonVsplFfuYx3pZ/GLCQfYE5cONduILLktsYjUpQ==
-  dependencies:
-    lodash-es "4"
-
 ktx-parse@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.4.5.tgz#79905e22281a9d3e602b2ff522df1ee7d1813aa6"
@@ -2345,11 +2300,6 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
-
-lodash-es@4:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.clamp@^4.0.3:
   version "4.0.3"
@@ -2557,37 +2507,6 @@ next@^13.4.12:
     "@next/swc-win32-arm64-msvc" "13.4.12"
     "@next/swc-win32-ia32-msvc" "13.4.12"
     "@next/swc-win32-x64-msvc" "13.4.12"
-
-ngraph.events@^1.0.0, ngraph.events@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/ngraph.events/-/ngraph.events-1.2.2.tgz#3ceb92d676a04a4e7ce60a09fa8e17a4f0346d7f"
-  integrity sha512-JsUbEOzANskax+WSYiAPETemLWYXmixuPAlmZmhIbIj6FH/WDgEGCGnRwUQBK0GjOnVm8Ui+e5IJ+5VZ4e32eQ==
-
-ngraph.forcelayout@3:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/ngraph.forcelayout/-/ngraph.forcelayout-3.3.1.tgz#981e1baee5e0593c490bc27219169f9cedfa4f8b"
-  integrity sha512-MKBuEh1wujyQHFTW57y5vd/uuEOK0XfXYxm3lC7kktjJLRdt/KEKEknyOlc6tjXflqBKEuYBBcu7Ax5VY+S6aw==
-  dependencies:
-    ngraph.events "^1.0.0"
-    ngraph.merge "^1.0.0"
-    ngraph.random "^1.0.0"
-
-ngraph.graph@20:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/ngraph.graph/-/ngraph.graph-20.0.1.tgz#579470d1d805583239704dc913e2095540aaf371"
-  integrity sha512-VFsQ+EMkT+7lcJO1QP8Ik3w64WbHJl27Q53EO9hiFU9CRyxJ8HfcXtfWz/U8okuoYKDctbciL6pX3vG5dt1rYA==
-  dependencies:
-    ngraph.events "^1.2.1"
-
-ngraph.merge@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ngraph.merge/-/ngraph.merge-1.0.0.tgz#d763cdfa48b1bbd4270ea246f06c9c8ff5d3477c"
-  integrity sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==
-
-ngraph.random@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ngraph.random/-/ngraph.random-1.1.0.tgz#5345c4bb63865c85d98ee6f13eab1395d8545a90"
-  integrity sha512-h25UdUN/g8U7y29TzQtRm/GvGr70lK37yQPvPKXXuVfs7gCm82WipYFZcksQfeKumtOemAzBIcT7lzzyK/edLw==
 
 node-fetch@^2.6.7:
   version "2.7.0"
@@ -3266,22 +3185,6 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-three-forcegraph@^1.41.10:
-  version "1.41.10"
-  resolved "https://registry.yarnpkg.com/three-forcegraph/-/three-forcegraph-1.41.10.tgz#a162263b5c5db957c88cb496baff057f12bb26ef"
-  integrity sha512-XrrH0HzlWQiY5A30RMtlu+SpAM/LOoHMyaQouCFgavTSLrSsP4UIUP3eWrfJ0be1xDPuMGt3iofSYjgu4UT2NA==
-  dependencies:
-    accessor-fn "1"
-    d3-array "1 - 3"
-    d3-force-3d "2 - 3"
-    d3-scale "1 - 4"
-    d3-scale-chromatic "1 - 3"
-    data-joint "1"
-    kapsule "1"
-    ngraph.forcelayout "3"
-    ngraph.graph "20"
-    tinycolor2 "1"
-
 three-mesh-bvh@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.6.1.tgz#63cebe46ff90221286f97e1fea59b433bb95304f"
@@ -3324,11 +3227,6 @@ tiny-warning@^1.0.0:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
-tinycolor2@1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.6.0.tgz#f98007460169b0263b97072c5ae92484ce02d09e"
-  integrity sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==
-
 titleize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
@@ -3356,15 +3254,35 @@ troika-three-text@^0.47.2:
     troika-worker-utils "^0.47.2"
     webgl-sdf-generator "1.1.1"
 
+troika-three-text@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/troika-three-text/-/troika-three-text-0.49.0.tgz#bc2dc1924250c477cd39316cd83585dee12550e0"
+  integrity sha512-sn9BNC6eIX8OO3iAkPwjecJ7Pn21Ve8P1UNFMNeQzXx759rrqS4i4pSZs7FLMYdWyCKVXBFGimBySFwRKLjq/Q==
+  dependencies:
+    bidi-js "^1.0.2"
+    troika-three-utils "^0.49.0"
+    troika-worker-utils "^0.49.0"
+    webgl-sdf-generator "1.1.1"
+
 troika-three-utils@^0.47.2:
   version "0.47.2"
   resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.47.2.tgz#af49ca694245dce631963d5fefe4e8e1b8af9044"
   integrity sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==
 
+troika-three-utils@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.49.0.tgz#3fbdbf8783740ce3c1f7acac642e7e957ea4f090"
+  integrity sha512-umitFL4cT+Fm/uONmaQEq4oZlyRHWwVClaS6ZrdcueRvwc2w+cpNQ47LlJKJswpqtMFWbEhOLy0TekmcPZOdYA==
+
 troika-worker-utils@^0.47.2:
   version "0.47.2"
   resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.47.2.tgz#e7c5de5f37d56c072b13fa8112bb844e048ff46c"
   integrity sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA==
+
+troika-worker-utils@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.49.0.tgz#e5e200a09d2e0e4eb9fe818a83effa912e2ec4b4"
+  integrity sha512-1xZHoJrG0HFfCvT/iyN41DvI/nRykiBtHqFkGaGgJwq5iXfIZFBiPPEHFpPpgyKM3Oo5ITHXP5wM2TNQszYdVg==
 
 tsconfig-paths@^3.14.1:
   version "3.14.2"


### PR DESCRIPTION
## 개요

- #68

## 작업사항
- 타입 수정
  - GraphData -> ThreeGraphData
  - MindMapResponse  -> GraphData
- WhiteBoard를 GraphCanvas로 대체
  - d3 force graph로 생성한 그래프를 렌더링
  - 상호작용 가능
- TODO:
  - GraphCanvas에서 선택한 노드 처리 (노드 설명 가져오기)
  - 툴바 및 인터페이스 수정
