### PR TITLE
노드 관련 기능들에 api 연결

### DIFF
--- a/app/document/[documentId]/page.module.css
+++ b/app/document/[documentId]/page.module.css
@@ -12,11 +12,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  color: var(--background);
 }
 
 .icon {
   text-align: center;
-  color: var(--background);
   rotate: 90deg;
 }
 
@@ -70,4 +70,30 @@
   flex-direction: row;
   min-height: 0;
   min-width: 0;
+}
+
+.alertContainer {
+  transition: transform 0.3s ease-out;
+  opacity: 0.9;
+  flex-direction: row;
+  margin-top: 10px;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  color: var(--primary-dark);
+  position: fixed;
+  background-color: var(--background);
+  border: 1px solid #c5c5c583;
+  border-radius: 10px 0 0 10px;
+  top: 0;
+  right: 0;
+}
+
+.alertContent {
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 10px;
+  flex-grow: 1;
 }

--- a/components/Card/index.tsx
+++ b/components/Card/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { timeDifference } from '../../utils/ui';
 import styles from './card.module.css';
 interface CardProps {
-  document: WBDocumentMetadata;
+  document: WBDocument;
 }
 
 export default function Card({ document }: CardProps) {

--- a/components/DataViewer/AudioViewer/index.tsx
+++ b/components/DataViewer/AudioViewer/index.tsx
@@ -102,7 +102,11 @@ function TextBubble({
   }));
 
   const keywordPos = useMemo(() => {
-    return mergePos(getKeywordPos(data.text, keywords)).reverse();
+    const keywordStr: string[] = [];
+    for (const [k, v] of keywords.entries()) {
+      if (v.enabled) keywordStr.push(k);
+    }
+    return mergePos(getKeywordPos(data.text, keywordStr)).reverse();
   }, [data.text, keywords]);
 
   const highlightedText = keywordPos.map((v, i) => {

--- a/components/DataViewer/OptionPanel/index.tsx
+++ b/components/DataViewer/OptionPanel/index.tsx
@@ -1,8 +1,10 @@
-import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import styles from './optionPanel.module.css';
 import 'material-symbols';
 import { useViewer } from '@/states/viewer';
 import SmallIconButton from '@/components/Button/SmallIconButton';
+import ClickableBackgroundButton from '@/components/BackgroundButton/ClickableBackgroundButton';
+import { updateKeywords } from '@/utils/api';
 
 const DEFAULT_WIDTH = 350;
 
@@ -13,11 +15,16 @@ interface OptionPanelProps {
 export default function OptionPanel({ children }: OptionPanelProps) {
   const [width, setWidth] = useState<number>(DEFAULT_WIDTH);
   const [drag, setDrag] = useState<boolean>(false);
-  const { keywords, currentTool, setCurrentTool } = useViewer((state) => ({
-    keywords: state.keywords,
-    currentTool: state.currentTool,
-    setCurrentTool: state.setCurrentTool,
-  }));
+  const [syncInProgress, setSyncInProgress] = useState<boolean>(false);
+  const { keywords, currentTool, setCurrentTool, documentId, syncDocument, clearSyncDocument } =
+    useViewer((state) => ({
+      keywords: state.keywords,
+      currentTool: state.currentTool,
+      setCurrentTool: state.setCurrentTool,
+      documentId: state.document?.documentId,
+      syncDocument: state.syncDocument,
+      clearSyncDocument: state.clearSyncDocument,
+    }));
 
   useEffect(() => {
     if (!drag) return;
@@ -32,13 +39,42 @@ export default function OptionPanel({ children }: OptionPanelProps) {
     };
   }, [drag]);
 
-  const keys = Array.from(keywords.keys());
+  const [stableKeys, addedKeys, removedKeys] = useMemo(() => {
+    const stable: string[] = [];
+    const added: string[] = [];
+    const removed: string[] = [];
+    for (const [k, v] of keywords.entries()) {
+      if (v.type === 'STABLE') stable.push(k);
+      else if (v.type === 'ADD') added.push(k);
+      else if (v.type === 'DELETE') removed.push(k);
+    }
+    return [stable, added, removed];
+  }, [keywords]);
+
+  const syncKeywords = () => {
+    if (documentId === undefined) return;
+    setSyncInProgress(true);
+    (async () => {
+      // clear prev document
+      clearSyncDocument();
+      // sync local changes
+      await updateKeywords(documentId, addedKeys, removedKeys);
+      // wait for sync to finish
+      // TODO: implement this
+      setTimeout(() => {
+        // done!
+        setSyncInProgress(false);
+        // reload document
+        syncDocument();
+      }, 3000);
+    })();
+  };
 
   return (
     <div className={styles.container} style={{ width: `${width}px` }}>
       <div
         className={styles.handle}
-        onPointerDown={(e) => {
+        onPointerDown={() => {
           setDrag(true);
         }}
       >
@@ -60,12 +96,51 @@ export default function OptionPanel({ children }: OptionPanelProps) {
             />
           </div>
         </div>
-        <div className={styles.keywords}>
-          {keys.map((v) => (
-            <KeywordView key={v} label={v} />
-          ))}
+        <div className={styles.keywordsContainer}>
+          <div
+            className={styles.keywords}
+            style={syncInProgress ? { pointerEvents: 'none', opacity: '0.5' } : undefined}
+          >
+            <KeywordHeader label={`변경 사항 (${addedKeys.length + removedKeys.length})`}>
+              {addedKeys.length + removedKeys.length > 0 ? (
+                <ClickableBackgroundButton
+                  text={'변경 사항 적용'}
+                  icon={'sync'}
+                  onClick={syncKeywords}
+                />
+              ) : (
+                <></>
+              )}
+            </KeywordHeader>
+            {addedKeys.map((v) => (
+              <KeywordView key={v} label={v} />
+            ))}
+            {removedKeys.map((v) => (
+              <KeywordView key={v} label={v} />
+            ))}
+          </div>
+          <div className={styles.keywords}>
+            <KeywordHeader label={`키워드 (${stableKeys.length})`} />
+            {stableKeys.map((v) => (
+              <KeywordView key={v} label={v} />
+            ))}
+          </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+interface KeywordHeaderProps {
+  label: string;
+  children?: ReactNode;
+}
+
+function KeywordHeader({ label, children }: KeywordHeaderProps) {
+  return (
+    <div className={styles.keywordHeaderContainer}>
+      <p className={styles.keywordsHeader}>{label}</p>
+      <div className={styles.keywordHeaderActions}>{children}</div>
     </div>
   );
 }
@@ -75,15 +150,17 @@ interface KeywordViewProps {
 }
 
 function KeywordView({ label }: KeywordViewProps) {
-  const { enabled, setKeyword } = useViewer((state) => ({
-    enabled: state.keywords.get(label),
+  const { state, setKeyword } = useViewer((state) => ({
+    state: state.keywords.get(label),
     setKeyword: state.setKeyword,
   }));
 
+  if (state === undefined) return <></>;
+
   return (
     <div
-      className={`${styles.keyword} ${enabled ? styles.enabled : ''}`}
-      onClick={() => setKeyword(label, !enabled)}
+      className={`${styles.keyword} ${state.enabled ? styles.enabled : ''}`}
+      onClick={() => setKeyword(label, !state.enabled)}
     >
       {label}
     </div>

--- a/components/DataViewer/OptionPanel/optionPanel.module.css
+++ b/components/DataViewer/OptionPanel/optionPanel.module.css
@@ -36,9 +36,18 @@
   align-items: center;
   justify-content: space-around;
   gap: 10px;
-  --background: var(--foreground);
   color: var(--background);
   text-align: center;
+}
+
+.keywordsContainer {
+  padding: 0 5px 5px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-sizing: border-box;
+  overflow: auto;
+  width: 100%;
 }
 
 .keywords {
@@ -47,9 +56,7 @@
   justify-content: center;
   width: 100%;
   flex-wrap: wrap;
-  padding: 10px;
   align-items: center;
-  overflow: auto;
   gap: 5px;
 }
 
@@ -70,6 +77,7 @@
   text-align: center;
   color: var(--background);
   rotate: 90deg;
+  user-select: none;
 }
 
 .tools {
@@ -77,4 +85,34 @@
   height: 46px;
   display: flex;
   align-items: center;
+}
+
+.keywordHeaderContainer {
+  background-color: var(--primary-dark);
+  min-height: 60px;
+  flex-wrap: wrap;
+  flex-grow: 1;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
+}
+
+.keywordHeaderActions {
+  gap: 10px;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.keywordsHeader {
+  color: var(--foreground);
+  margin: 0;
+  flex-grow: 0;
 }

--- a/components/NodeInfo/index.tsx
+++ b/components/NodeInfo/index.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import styles from './nodeInfo.module.css';
-import { lipsum } from '@/utils/whiteboardHelper';
 import SmallActionButton from '../Button/SmallActionButton';
 import { useViewer } from '@/states/viewer';
 import RelationView from './RelationView';
 import SourceDataView from './SourceDataView';
+import { getKeywordInfo } from '@/utils/api';
 
 interface NodeInfoProps {
   node?: NodeData;
@@ -13,13 +13,17 @@ export default function NodeInfo({ node }: NodeInfoProps) {
   const [data, setData] = useState<string>();
   const [sourceView, setSourceView] = useState<boolean>(true);
   const [relationView, setRelationView] = useState<boolean>(true);
+  const documentId = useViewer((state) => state.document?.documentId);
 
   useEffect(() => {
-    // TODO: fetch node data
-    if (node === undefined) return;
-    setData(lipsum);
+    if (node === undefined || documentId === undefined) return;
+    (async () => {
+      const data = await getKeywordInfo(documentId, node.label);
+      setData(data.text);
+    })();
+
     return () => setData(undefined);
-  }, [node]);
+  }, [documentId, node]);
 
   const { setFocus, setView } = useViewer((state) => ({
     setFocus: state.focusNodeCallback,

--- a/global.d.ts
+++ b/global.d.ts
@@ -54,7 +54,7 @@ interface CircleOptions {
   color?: string;
 }
 
-type ViewerPage = 'HOME' | 'DATA';
+type ViewerPage = 'HOME' | 'DATA' | 'LOAD';
 
 interface ThreeGraphData {
   nodes: NodeDataLegacy[];
@@ -219,4 +219,10 @@ interface KeywordSourceResult {
   str: string;
   keyword: string;
   location: number[];
+}
+
+type KeywordType = 'ADD' | 'STABLE' | 'DELETE';
+interface KeywordState {
+  enabled: boolean;
+  type: KeywordType;
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -226,3 +226,7 @@ interface KeywordState {
   enabled: boolean;
   type: KeywordType;
 }
+
+interface KeywordResponse {
+  text: string;
+}

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -17,7 +17,7 @@ export async function createDocument(documentName: string): Promise<WBDocumentCr
 }
 
 export async function deleteDocument(documentId: number) {
-  await httpDelete(`${API_BASE_URL}/documents/${documentId}`);
+  await httpDelete(`${API_BASE_URL}/documents/${documentId}`, null);
 }
 
 export async function getUserData(): Promise<UserDataResponse> {
@@ -39,4 +39,12 @@ export async function getDataSource(
   type: WBSourceDataType,
 ): Promise<WBSourceData> {
   return (await httpGet(`${API_BASE_URL}/documents/${documentId}/${type}`))?.json();
+}
+
+export async function deleteKeywords(documentId: number, keywords: string[]) {
+  return await httpDelete(`${API_BASE_URL}/mindmap/keyword`, { keywords }, true);
+}
+
+export async function addKeywords(documentId: number, keywords: string[]) {
+  return await httpPost(`${API_BASE_URL}/mindmap/keyword`, { keywords }, true);
 }

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -47,3 +47,12 @@ export async function updateKeywords(documentId: number, addition: string[], del
     delete: deletion,
   });
 }
+
+export async function getKeywordInfo(
+  documentId: number,
+  keyword: string,
+): Promise<KeywordResponse> {
+  return (
+    await httpGet(`${API_BASE_URL}/documents/${documentId}/mindmap/keyword/${keyword}`)
+  )?.json();
+}

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,4 +1,4 @@
-import { httpDelete, httpGet, httpPost } from './http';
+import { httpDelete, httpGet, httpPost, httpPut } from './http';
 
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 export const AI_BASE_URL = process.env.NEXT_PUBLIC_AI_BASE_URL;
@@ -41,10 +41,9 @@ export async function getDataSource(
   return (await httpGet(`${API_BASE_URL}/documents/${documentId}/${type}`))?.json();
 }
 
-export async function deleteKeywords(documentId: number, keywords: string[]) {
-  return await httpDelete(`${API_BASE_URL}/mindmap/keyword`, { keywords }, true);
-}
-
-export async function addKeywords(documentId: number, keywords: string[]) {
-  return await httpPost(`${API_BASE_URL}/mindmap/keyword`, { keywords }, true);
+export async function updateKeywords(documentId: number, addition: string[], deletion: string[]) {
+  return await httpPut(`${API_BASE_URL}/documents/${documentId}/mindmap/keyword`, {
+    add: addition,
+    delete: deletion,
+  });
 }

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -28,6 +28,14 @@ export async function httpPost(url: string, body: any, retry: boolean = true) {
   return doGetRes(getRes, headers, retry);
 }
 
+export async function httpPut(url: string, body: any, retry: boolean = true) {
+  const headers = createHeaders();
+  const getRes = (headers: Headers) =>
+    fetch(url, { method: 'PUT', headers: headers, body: JSON.stringify(body) });
+
+  return doGetRes(getRes, headers, retry);
+}
+
 export async function httpDelete(url: string, body: any, retry: boolean = true) {
   const headers = createHeaders();
   const getRes = (headers: Headers) =>

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -28,9 +28,10 @@ export async function httpPost(url: string, body: any, retry: boolean = true) {
   return doGetRes(getRes, headers, retry);
 }
 
-export async function httpDelete(url: string, retry: boolean = true) {
+export async function httpDelete(url: string, body: any, retry: boolean = true) {
   const headers = createHeaders();
-  const getRes = (headers: Headers) => fetch(url, { method: 'DELETE', headers: headers });
+  const getRes = (headers: Headers) =>
+    fetch(url, { method: 'DELETE', headers: headers, body: JSON.stringify(body) });
 
   return doGetRes(getRes, headers, retry);
 }

--- a/utils/viewerHelper.ts
+++ b/utils/viewerHelper.ts
@@ -1,4 +1,10 @@
-export function highlightKeywordStr(input: string, keywords: Map<string, boolean>) {
+export function highlightKeywordStr(input: string, keywordStates: Map<string, KeywordState>) {
+  // get keywords
+  const keywords: string[] = [];
+  for (const [k, v] of keywordStates.entries()) {
+    if (v.enabled) keywords.push(k);
+  }
+
   // highlights keywords
   const pos = getKeywordPos(input, keywords);
 
@@ -11,15 +17,14 @@ export function highlightKeywordStr(input: string, keywords: Map<string, boolean
   return str;
 }
 
-export function getKeywordPos(input: string, keywords: Map<string, boolean>) {
+export function getKeywordPos(input: string, keywords: string[]) {
   const pos: Pos[] = [];
-  for (const [s, f] of keywords.entries()) {
+  for (const keyword of keywords) {
     // find all occurences
-    if (!f) continue;
-    const matches = input.matchAll(new RegExp(s, 'gi'));
+    const matches = input.matchAll(new RegExp(keyword, 'gi'));
     for (const m of matches) {
       if (m.index === undefined) continue;
-      pos.push({ start: m.index, end: m.index + s.length });
+      pos.push({ start: m.index, end: m.index + keyword.length });
     }
   }
   return pos;


### PR DESCRIPTION
## 개요

- Closes #73 

## 작업사항

- 키워드 추가 api
  - 상태 타입 생성 및 관리 (stable: 기존의 키워드, add: 추가 예정인 키워드, remove: 삭제 예정인 키워드)
  - 키워드에 변경 사항이 있을 경우, 바로 적용하지 않음 -> 사용자에게 버튼 제공하여 클릭시 요청
    <img width="339" alt="image" src="https://github.com/SWM-SMART/watchboard-front/assets/97426534/af033e8e-fe18-4f12-af2c-e5a39e055b84">

  - 요청후 처리 시간 동안에 조작 가능, 백그라운드에서 새로운 마인드맵 로드해둠, 로드 완료시 알림 표시하여 원하는 시기에 변경사항이 적용된 마인드맵으로 업데이트 가능
    <img width="351" alt="image" src="https://github.com/SWM-SMART/watchboard-front/assets/97426534/ad866051-0df9-466e-8314-3cace082f15c">

- NodeInfo api
