### PR TITLE
api 변경에 따른 수정사항 #2

### DIFF
--- a/app/components/Header/header.module.css
+++ b/app/components/Header/header.module.css
@@ -1,5 +1,5 @@
 .header {
-  position: fixed;
+  position: sticky;
   top: 0;
   z-index: 100;
   display: flex;
@@ -11,6 +11,7 @@
   align-items: center;
   width: 100%;
   height: 65px;
+  flex: 0 0 65px;
   padding: 0 20px;
 }
 

--- a/app/components/Header/header.module.css
+++ b/app/components/Header/header.module.css
@@ -1,4 +1,7 @@
 .header {
+  position: fixed;
+  top: 0;
+  z-index: 100;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -7,7 +10,7 @@
   border-bottom: 1px solid #e5e8ec;
   align-items: center;
   width: 100%;
-  flex: 0 0 65px;
+  height: 65px;
   padding: 0 20px;
 }
 

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -6,7 +6,7 @@ import { useOverlay } from '@/states/overlay';
 import DocumentCreateDialogue from '../DocumentCreateDialogue';
 import Logo from '@/components/Logo';
 import { useUser } from '@/states/user';
-import { useViewer } from '@/states/viewer';
+
 export default function Header() {
   const { setOverlay } = useOverlay((state) => ({
     setOverlay: state.setOverlay,

--- a/app/document/[documentId]/page.tsx
+++ b/app/document/[documentId]/page.tsx
@@ -30,7 +30,6 @@ export default function DoucumentsPage({ params }: DocumentPageProps) {
       syncDocument: state.syncDocument,
     }),
   );
-  const [nodeInfoString, setNodeInfoString] = useState<string | null>(null);
 
   // reset viewer
   useEffect(() => {
@@ -41,16 +40,8 @@ export default function DoucumentsPage({ params }: DocumentPageProps) {
 
   const { width, setDrag } = useDivider(true, 800, 0);
 
-  const loadNodeInfo = (node: NodeData) => {
-    (async () => {
-      const data = await getKeywordInfo(node.documentId, node.label);
-      setNodeInfoString(data?.text ?? null);
-    })();
-  };
-
   const eventCallback = useCallback(
     (type: ViewerEventType, data: string) => {
-      console.log(type);
       // reload on event
       if (type === 'mindmap') {
         // mindmap reload
@@ -58,24 +49,12 @@ export default function DoucumentsPage({ params }: DocumentPageProps) {
         // mindmap updated
         return syncDocument();
       }
-
-      if (type === 'answer' && selectedNode !== undefined) {
-        // answers are loaded
-        if (selectedNode.label) return loadNodeInfo(selectedNode);
-      }
     },
-    [documentData, documentId, loadDocument, selectedNode, syncDocument],
+    [documentData, documentId, loadDocument, syncDocument],
   );
 
   // subscribe to events
-  useViewerEvents(documentId, eventCallback);
-
-  // fetch nodeInfo
-  useEffect(() => {
-    if (selectedNode === undefined) return;
-    loadNodeInfo(selectedNode);
-    return () => setNodeInfoString(null);
-  }, [documentId, selectedNode]);
+  useViewerEvents(eventCallback, documentId);
 
   if (documentData === null) return <LoadingScreen message={'요약 마인드맵 로드중'} />;
 
@@ -83,7 +62,7 @@ export default function DoucumentsPage({ params }: DocumentPageProps) {
     <div className={styles.rootContainer}>
       <div className={styles.container}>
         <div className={styles.sideBar} style={{ width: `${width}px`, flex: `0 0 ${width}px` }}>
-          <NodeInfo node={selectedNode} answer={nodeInfoString} />
+          <NodeInfo node={selectedNode} />
         </div>
         <Divider setDrag={setDrag} />
         <div className={styles.content}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ToastViewer />
         <div className={styles.container}>
           <Header />
-          <div className={styles.children}>{children}</div>
+          {children}
         </div>
         <OverlayViewer />
         <ContextMenuViewer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ToastViewer />
         <div className={styles.container}>
           <Header />
-          {children}
+          <div className={styles.children}>{children}</div>
         </div>
         <OverlayViewer />
         <ContextMenuViewer />

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -5,6 +5,14 @@
   width: 100%;
 }
 
+.children {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  margin-top: 65px;
+}
+
 .content {
   animation: var(--intro-animation);
   box-sizing: border-box;

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -3,14 +3,7 @@
   flex-direction: column;
   height: 100%;
   width: 100%;
-}
-
-.children {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
-  margin-top: 65px;
+  overflow: auto;
 }
 
 .content {

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -5,12 +5,13 @@ import Link from 'next/link';
 interface ButtonProps {
   text: string;
   icon?: string;
+  highlight?: boolean;
   href: string;
 }
 
-export default function Button({ text, icon, href }: ButtonProps) {
+export default function Button({ text, icon, href, highlight = true }: ButtonProps) {
   return (
-    <Link href={href}>
+    <Link href={href} style={highlight ? undefined : { color: 'var(--primary-dark)' }}>
       <div className={styles.container}>
         <span className={styles.text}>{text}</span>
         {icon === undefined ? null : (

--- a/components/Card/index.tsx
+++ b/components/Card/index.tsx
@@ -1,13 +1,36 @@
+'use client';
 import Link from 'next/link';
 import { timeDifference } from '../../utils/ui';
 import styles from './card.module.css';
+import { ContextMenuItem, useContextMenu } from '@/states/contextMenu';
+import { deleteDocument } from '@/utils/api';
+import { useDocument } from '@/states/document';
 interface CardProps {
   document: WBDocument;
 }
 
 export default function Card({ document }: CardProps) {
+  const setMenu = useContextMenu((state) => state.setMenu);
+  const deleteDocument = useDocument((state) => state.deleteDocument);
   return (
-    <Link href={`/document/${document.documentId}`} className={styles.link}>
+    <Link
+      href={`/document/${document.documentId}`}
+      className={styles.link}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenu({
+          items: [
+            {
+              onClick: async () => {
+                deleteDocument(document.documentId);
+              },
+              label: `삭제`,
+            },
+          ],
+          position: { x: e.pageX, y: e.pageY },
+        });
+      }}
+    >
       <div className={styles.card}>
         <div className={styles.preview}></div>
         <div className={styles.labelContainer}>

--- a/components/GraphCanvas/GraphRenderer.tsx
+++ b/components/GraphCanvas/GraphRenderer.tsx
@@ -418,8 +418,8 @@ function useSimulation(
       // save links in nodes for future use
       for (const link of newLinks) {
         linksRef.current.push(link);
-        nodesMap.get(link.source as string)!.children?.push(nodesMap.get(link.target as string)!);
-        nodesMap.get(link.target as string)!.parent = nodesMap.get(link.source as string);
+        nodesMap.get(link.source as string)!.children.push(nodesMap.get(link.target as string)!);
+        nodesMap.get(link.target as string)!.children.push(nodesMap.get(link.source as string)!);
       }
     }
 
@@ -441,7 +441,7 @@ function useSimulation(
 
     simulationRef.current.alpha(1).stop();
     invalidate();
-  }, [data, groupRef, linkDataFactory, nodeDataFactory]);
+  }, [data, groupRef, linkDataFactory, meshFactory, nodeDataFactory]);
 
   // simulation tick on frame
   useFrame((_state, delta) => {

--- a/components/NodeInfo/RelationView/index.tsx
+++ b/components/NodeInfo/RelationView/index.tsx
@@ -11,18 +11,6 @@ export default function RelationView({ node, hidden = false }: RelationViewProps
     <div className={styles.container} style={hidden ? { display: 'none' } : undefined}>
       <div className={styles.nodeContainer}>
         <div className={styles.node}>
-          <div
-            className={styles.label}
-            onClick={() => {
-              if (node.parent != undefined) setSelectedNode(node.parent);
-            }}
-          >
-            {node.parent?.label}
-          </div>
-        </div>
-      </div>
-      <div className={styles.nodeContainer}>
-        <div className={styles.node}>
           <div className={`${styles.label} ${styles.current}`}>{node.label}</div>
         </div>
       </div>

--- a/global.d.ts
+++ b/global.d.ts
@@ -68,7 +68,6 @@ type ExtendedSpriteText = import('three-spritetext').default & {
 interface NodeData {
   documentId: number;
   children: NodeData[];
-  parent?: NodeData;
   id: string;
   label: string;
   labelMesh?: ExtendedSpriteText;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@react-three/drei": "^9.78.2",
     "@react-three/fiber": "^8.13.5",
     "@types/d3": "^7.4.0",
+    "@types/event-source-polyfill": "^1.0.4",
     "@types/node": "20.4.2",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.7",

--- a/states/document.ts
+++ b/states/document.ts
@@ -1,15 +1,22 @@
-import { getDocumentList } from '@/utils/api';
+import DocumentList from '@/app/components/DocumentList';
+import { deleteDocument, getDocumentList } from '@/utils/api';
 import { create } from 'zustand';
 
 interface DocumentState {
   documentList: WBDocument[];
   fetchDocumentList: () => void;
+  deleteDocument: (documentId: number) => void;
 }
 
-export const useDocument = create<DocumentState>()((set) => ({
+export const useDocument = create<DocumentState>()((set, get) => ({
   documentList: [],
   fetchDocumentList: async () => {
     const newList = (await getDocumentList()) as WBDocument[];
     set(() => ({ documentList: newList }));
+  },
+  deleteDocument: async (documentId: number) => {
+    const res = await deleteDocument(documentId);
+    if (res !== 200) return;
+    set({ documentList: get().documentList.filter((v) => v.documentId !== documentId) });
   },
 }));

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -17,7 +17,8 @@ export async function createDocument(documentName: string): Promise<WBDocumentCr
 }
 
 export async function deleteDocument(documentId: number) {
-  await httpDelete(`${API_BASE_URL}/documents/${documentId}`, null);
+  const res = await httpDelete(`${API_BASE_URL}/documents/${documentId}`, null);
+  return res?.status;
 }
 
 export async function getUserData(): Promise<UserDataResponse> {
@@ -26,7 +27,9 @@ export async function getUserData(): Promise<UserDataResponse> {
 
 export async function refreshToken(): Promise<string | null> {
   return (
-    (await httpGet(`${API_BASE_URL}/users/token`, false, true))?.headers.get('Authorization') || ''
+    (await httpGet(`${API_BASE_URL}/users/token`, false, true, true))?.headers.get(
+      'Authorization',
+    ) || ''
   );
 }
 

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -56,8 +56,15 @@ export async function updateKeywords(documentId: number, addition: string[], del
 export async function getKeywordInfo(
   documentId: number,
   keyword: string,
+  signal?: AbortSignal,
 ): Promise<KeywordResponse | null> {
-  const res = await httpGet(`${API_BASE_URL}/documents/${documentId}/mindmap/keyword/${keyword}`);
+  const res = await httpGet(
+    `${API_BASE_URL}/documents/${documentId}/mindmap/keyword/${keyword}`,
+    true,
+    true,
+    false,
+    signal,
+  );
   if (res?.status === 200) return res?.json();
   return null;
 }

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -4,7 +4,12 @@ import { refreshToken } from './api';
 import { throwError } from './ui';
 
 // refresh token on failure
-export async function httpGet(url: string, retry: boolean = true, credentials: boolean = false) {
+export async function httpGet(
+  url: string,
+  retry: boolean = true,
+  credentials: boolean = false,
+  silent: boolean = false,
+) {
   const headers = createHeaders();
   const getRes = (headers: Headers) =>
     fetch(url, {
@@ -12,7 +17,7 @@ export async function httpGet(url: string, retry: boolean = true, credentials: b
       headers: headers,
       credentials: credentials ? 'include' : undefined,
     });
-  return doGetRes(getRes, headers, retry);
+  return doGetRes(getRes, headers, retry, silent);
 }
 
 export async function httpPost(
@@ -20,6 +25,7 @@ export async function httpPost(
   body: any,
   retry: boolean = true,
   json: boolean = true,
+  silent: boolean = false,
 ) {
   const headers = createHeaders();
   if (json) headers.set('Content-Type', 'application/json');
@@ -29,26 +35,36 @@ export async function httpPost(
       headers: headers,
       body: json ? JSON.stringify(body) : body,
     });
-  return doGetRes(getRes, headers, retry);
+  return doGetRes(getRes, headers, retry, silent);
 }
 
-export async function httpPut(url: string, body: any, retry: boolean = true) {
+export async function httpPut(
+  url: string,
+  body: any,
+  retry: boolean = true,
+  silent: boolean = false,
+) {
   const headers = createHeaders();
   const getRes = (headers: Headers) =>
     fetch(url, { method: 'PUT', headers: headers, body: JSON.stringify(body) });
 
-  return doGetRes(getRes, headers, retry);
+  return doGetRes(getRes, headers, retry, silent);
 }
 
-export async function httpDelete(url: string, body: any, retry: boolean = true) {
+export async function httpDelete(
+  url: string,
+  body: any,
+  retry: boolean = true,
+  silent: boolean = false,
+) {
   const headers = createHeaders();
   const getRes = (headers: Headers) =>
     fetch(url, { method: 'DELETE', headers: headers, body: JSON.stringify(body) });
 
-  return doGetRes(getRes, headers, retry);
+  return doGetRes(getRes, headers, retry, silent);
 }
 
-function createHeaders() {
+export function createHeaders() {
   const accessToken = useUser.getState().accessToken;
   const headers = new Headers();
   if (accessToken.length > 0) headers.set('Authorization', accessToken);
@@ -67,14 +83,16 @@ async function doGetRes(
   getRes: (headers: Headers) => Promise<Response>,
   headers: Headers,
   retry: boolean,
+  silent?: boolean,
 ): Promise<Response | undefined> {
   try {
     const res = await getRes(headers);
+    // todo: retry only 401
     if (res.status >= 400) throw Error;
     return res;
   } catch (e) {
-    if (e instanceof Error && e.message.length > 0) throwError(e.message);
     if (!retry) return;
+    if (!silent && e instanceof Error && e.message.length > 0) throwError(e.message);
     if ((await preRetry(headers)) === false) return;
   }
   return await doGetRes(getRes, headers, false);

--- a/utils/ui.ts
+++ b/utils/ui.ts
@@ -1,6 +1,9 @@
 'use client';
 import { useEffect } from 'react';
 import { API_BASE_URL } from './api';
+import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
+import { useUser } from '@/states/user';
+const EventSource = EventSourcePolyfill || NativeEventSource;
 
 const DAY = 86400000;
 const HOUR = 3600000;
@@ -40,16 +43,19 @@ export function useError(callback: (msg: string) => void) {
 }
 
 export function useViewerEvents(
-  documentId: number,
   callback: (type: ViewerEventType, data: string) => void,
+  documentId?: number,
 ) {
+  const accessToken = useUser((state) => state.accessToken);
   useEffect(() => {
+    if (documentId === undefined) return;
     const eventSource = new EventSource(`${API_BASE_URL}/documents/${documentId}/subscribe`, {
       withCredentials: true,
+      headers: { Authorization: accessToken },
     });
-    eventSource.addEventListener('mindmap', (e) => callback('mindmap', e.data));
-
-    eventSource.addEventListener('answer', (e) => callback('answer', e.data));
+    eventSource.addEventListener('sse', (e) => console.log('connection open', e));
+    eventSource.addEventListener('mindmap', (e) => callback('mindmap', (e as any)!.data));
+    eventSource.addEventListener('answer', (e) => callback('answer', (e as any)!.data));
     return () => eventSource.close();
-  }, [callback, documentId]);
+  }, [accessToken, callback, documentId]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,11 @@
   resolved "https://registry.yarnpkg.com/@types/draco3d/-/draco3d-1.4.2.tgz#7faccb809db2a5e19b9efb97c5f2eb9d64d527ea"
   integrity sha512-goh23EGr6CLV6aKPwN1p8kBD/7tT5V/bLpToSbarKrwVejqNrspVrv8DhliteYkkhZYrlq/fwKZRRUzH4XN88w==
 
+"@types/event-source-polyfill@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/event-source-polyfill/-/event-source-polyfill-1.0.4.tgz#566fe195ad2e583e3d597c30d0fd314eac74c6f6"
+  integrity sha512-vkNHHMGWl5PieP9E2gkCpLOMjbVXkf1ViDcGmxlJy8QwL7URh/Y5Tk5S/PMKlof/Eslx1oZUeuKXKgUxf74iOA==
+
 "@types/geojson@*":
   version "7946.0.10"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.10.tgz#6dfbf5ea17142f7f9a043809f1cd4c448cb68249"


### PR DESCRIPTION
## 개요

- #118

## 작업사항

- 페이지 레이아웃 수정: sticky 헤더
- useViewer에서 event source polyfill 사용
- card에 context menu 추가: 문서 삭제 기능 구현
- http 요청시 silent(오류 발생시 이벤트 발행 하지 않음)과 abort signal(Get만) 옵션 추가
- sse연결 분리: 마인드맵과 노드 정보 이벤트 connection 분리
